### PR TITLE
fix: review workflow 403 and git repo errors

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   issues: write
   actions: read
@@ -202,7 +202,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             COMMIT_SHA="${{ github.event.workflow_run.head_sha }}"
           else
-            COMMIT_SHA=$(git -C /tmp ls-remote https://github.com/${{ github.repository }}.git HEAD 2>/dev/null | cut -f1 || echo "${{ github.sha }}")
+            COMMIT_SHA="${{ github.sha }}"
           fi
 
           # Post commit comment via GitHub API
@@ -215,6 +215,7 @@ jobs:
           # Create issue if failed
           if [ "$REVIEW_STATUS" = "fail" ]; then
             gh issue create \
+              --repo "${{ github.repository }}" \
               --title "Dashboard review failed - deployment ${{ github.run_id }}" \
               --body "## Review Failed
 


### PR DESCRIPTION
- contents: write permission (was read) to allow posting commit comments
- remove broken git ls-remote call; use github.sha directly for workflow_dispatch
- add --repo flag to gh issue create (no checkout step in this job)

https://claude.ai/code/session_01DZHSG463Cgzqm8WJ3PjoUP